### PR TITLE
Call external process-dim-armor.py script

### DIFF
--- a/d2utils.ipynb
+++ b/d2utils.ipynb
@@ -192,7 +192,7 @@
    "source": [
     "### Ignore armor tagged as `infuse` or `junk` in DIM\n",
     "\n",
-    "If you export your vault in DIM as a CSV, this can parse it and find the armor that the `d2armor` notebook can filter out."
+    "If you [export your vault in DIM as a CSV](https://github.com/DestinyItemManager/DIM/wiki/Spreadsheets#), this can parse it and build a list of armor that the `d2armor` notebook should exclude from analysis. Adding \"#ignore\" to a DIM item's Notes field has the same effect — this can be used to exclude things like raid class items, which aren't junk, but are irrelevant to outfit calculations. "
    ]
   },
   {
@@ -209,28 +209,7 @@
     }
    ],
    "source": [
-    "import csv\n",
-    "import os\n",
-    "import json\n",
-    "\n",
-    "armor_csv_path = f\"{os.getenv('HOME')}/Downloads/destinyArmor.csv\"\n",
-    "ignored_armor_path = \"data/ignored-armor.json\"\n",
-    "\n",
-    "if not os.path.exists(armor_csv_path):\n",
-    "    print(f\"Could not find {armor_csv_path}\")\n",
-    "else:\n",
-    "    with open(armor_csv_path) as csv_file:\n",
-    "        csv_reader = csv.reader(csv_file, delimiter=\",\")\n",
-    "        line_count = 0\n",
-    "        ignored = []\n",
-    "        for row in csv_reader:\n",
-    "            if row[3] == \"infuse\" or row[3] == \"junk\":\n",
-    "                ignored.append(\n",
-    "                    dict(instance_id=row[2].strip('\"'), name=row[0], tag=row[3])\n",
-    "                )\n",
-    "        with open(ignored_armor_path, \"w\", encoding=\"utf-8\") as f:\n",
-    "            json.dump(ignored, f, indent=2)\n",
-    "        print(f\"wrote {len(ignored)} items to {ignored_armor_path}\")"
+    "%run src/process-dim-armor.py\n"
    ]
   }
  ],

--- a/src/process-dim-armor.py
+++ b/src/process-dim-armor.py
@@ -1,0 +1,32 @@
+import argparse
+import csv
+import os
+import json
+import re
+from pathlib import Path
+
+desc = "Process DIM armor exports to tell d2noteboooks what to ignore."
+parser = argparse.ArgumentParser( description=desc )
+parser.add_argument( '-f', '--file', default=f"{os.getenv('HOME')}/Downloads/destinyArmor.csv" )
+args = parser.parse_args()
+
+armor_csv_path = args.file
+ignored_armor_path = f"{Path(__file__).parent.parent}/data/ignored-armor.json"
+
+if not os.path.exists(armor_csv_path):
+    print(f"Could not find {armor_csv_path}")
+else:
+	with open(armor_csv_path) as csv_file:
+		csv_reader = csv.reader(csv_file, delimiter=',')
+		line_count = 0
+		ignored = []
+		for row in csv_reader:
+			if row[3] == "infuse" or row[3] == "junk" or re.search("#ignore", row[33]):
+				ignored.append(dict( instance_id = int(row[2].strip('"')), 
+									 name = row[0], 
+									 tag = ("#ignore" if re.search("#ignore", row[33]) else row[3])))
+
+		with open(ignored_armor_path, 'w', encoding="utf-8") as f:
+			json.dump(ignored, f, indent = 2)
+
+		print(f"wrote {len(ignored)} items to {ignored_armor_path}")


### PR DESCRIPTION
I built a little Hazel script to automatically process `destinyArmor.csv` files that appear in the Downloads folder, which motivated breaking the script out of the notebook to call it separately. I also added support for handling `#ignore` tags in the notes field like the junk and infuse tags.