### PR TITLE
Support non-cross-savers

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -3,3 +3,4 @@ data
 config.json
 *.pyc
 __pycache__
+.DS_Store

--- a/src/bungie_api.py
+++ b/src/bungie_api.py
@@ -45,9 +45,12 @@ class BungieApi:
                 ]
                 == membership_type
             ):
-                print(f"Crosave override found for {membership_id}")
-                return membership_id, membership_type
 
+                print(f"Cross-save override found for {membership_id}")
+            
+            return membership_id, membership_type
+            
+        print("Found nothing in get_primary_membership_id_and_type!")
         return (None, None)
 
     def get_character_ids_and_classes(self, membership_id, membership_type):


### PR DESCRIPTION
A pal tried this out and ended up with a bad profile URL:

```
HTTPError: 500 Server Error: InternalServererror for url: https://www.bungie.net/Platform/Destiny2/None/Profile/None/?components=[...]
```

De-indenting the return statement fixes it for him, and still works for me, a PSN to XBL émigré. 